### PR TITLE
UI: pH–time preview, B_meas vs pH with B_model overlay, and JSON/CSV export

### DIFF
--- a/app/frontend/src/api/client.ts
+++ b/app/frontend/src/api/client.ts
@@ -118,3 +118,46 @@ export async function compute(
 
   return res.json() as Promise<ComputeResponse>;
 }
+
+/* ---------------------------------------------------------------------------
+ *  Export helpers
+ * ------------------------------------------------------------------------- */
+
+export interface ExportResponse {
+  filename: string;
+  content_type: string;
+  // The backend returns either a CSV string or a JSON-serialisable object.
+  data: any;
+}
+
+/**
+ * Export data (processed table, peaks, or full session) from the backend.
+ *
+ * @param format    'csv' or 'json'
+ * @param dataType  'processed' | 'peaks' | 'session'
+ * @returns         Object containing filename suggestion, MIME type and payload
+ */
+export async function exportData(
+  format: 'csv' | 'json',
+  dataType: 'processed' | 'peaks' | 'session',
+): Promise<ExportResponse> {
+  const body = {
+    format,
+    data_type: dataType,
+    include_plots: false,
+  };
+
+  const res = await fetch('/api/export', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Export failed: ${await res.text()}`);
+  }
+
+  return res.json() as Promise<ExportResponse>;
+}


### PR DESCRIPTION
Droid-assisted PR

Summary
- Add pH vs time preview plot to confirm correct import/mapping
- Add measured vs model base plot (B_meas and B_model over pH)
- Add Export buttons (Processed CSV/JSON, Peaks JSON, Session JSON)
- Add exportData() client API helper
- Clarify UI text describing what is calculated and how

Files
- app/frontend/src/App.tsx
- app/frontend/src/api/client.ts

Verification
- Backend tests: 44 passed (pytest) on local environment
- Frontend build: success (Vite). App loads and plots render with sample data

Rationale
- Addresses user feedback that the initial charts looked off and the UI lacked clarity
- pH vs time preview validates import/column mapping quickly
- B_meas vs pH with B_model overlay enables visual confirmation of modeling
- JSON/CSV export supports troubleshooting and downstream analysis

Notes
- No backend logic changes in this PR
- Large Plotly bundle triggers Vite chunk size warning (expected)

Please review. 

---
**Factory Session:** https://app.factory.ai/sessions/KDk6DdPWHS4EriIrwm40 (created by szymonwoj@gmail.com)