### PR TITLE
UI improvements + single JSON export: dark mode, responsive ΔB/dΔB, remove mapping/table, row-wise Settings with tooltips

### DIFF
--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -1,42 +1,90 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+/* Dark-mode friendly base theme using CSS variables */
+:root {
+  --bg: #ffffff;
+  --fg: #111827; /* gray-900 */
+  --muted: #4b5563; /* gray-600 */
+  --card-bg: #f5f5f7;
+  --accent: #2563eb; /* blue-600 */
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f172a; /* slate-900 */
+    --fg: #e5e7eb; /* gray-200 */
+    --muted: #94a3b8; /* slate-400 */
+    --card-bg: #111827; /* gray-900 */
+    --accent: #60a5fa; /* blue-400 */
   }
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+html, body {
+  background: var(--bg);
+  color: var(--fg);
 }
 
-.card {
-  padding: 2em;
+.container {
+  color: var(--fg);
 }
 
-.read-the-docs {
-  color: #888;
+section {
+  margin-bottom: 1.5rem;
+}
+
+section.cardish {
+  background: var(--card-bg);
+  border: 1px solid rgba(0,0,0,0.08);
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+input, select, button, textarea {
+  background-color: var(--bg);
+  color: var(--fg);
+  border: 1px solid rgba(0,0,0,0.15);
+  padding: 4px 6px;
+  border-radius: 4px;
+}
+
+button {
+  background: var(--accent);
+  color: white;
+  border: none;
+  padding: 6px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* Setting styles */
+.setting-row {
+  margin: 10px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.setting-row label {
+  margin-bottom: 4px;
+}
+
+.setting-description {
+  font-size: 16px;
+  margin: 8px 0;
+  color: var(--muted);
+}
+
+/* Remove default template styles */
+#root { 
+  max-width: 1280px; 
+  margin: 0 auto; 
+  padding: 1.25rem; 
+  text-align: left; 
+}
+
+.logo, .card, .read-the-docs { 
+  display: none; 
 }


### PR DESCRIPTION
Droid-assisted PR

Summary
- ΔB and dΔB/dpH responsiveness:
  • “Use pH-aligned ΔB” toggle is independent of overlay.
  • ΔB vs pH uses matched X/Y arrays; derivative computed on-the-fly from the selected ΔB (raw, pH‑aligned, or contacted).
- Dark mode:
  • CSS variables theme; Plotly layouts use transparent backgrounds and theme-aware font/grid colors.
- UI cleanup:
  • Removed “Map columns” UI (auto-mapping retained).
  • Removed processed-data table (export covers it).
  • Settings are one-per-row with hover tooltips.
  • Description is always visible and larger.
- Export simplification:
  • Single “Export all (JSON)” button that downloads a session JSON (settings, processed, model incl. standalone & pH‑aligned/contacted arrays, peaks, c_a).

Verification
- Backend tests (earlier run): 44/44 passing.
- Frontend builds successfully (vite build).

Files
- app/frontend/src/App.tsx
- app/frontend/src/App.css

Let me know if you want follow-ups (e.g., code-splitting the large JS bundle, or adding a light/dark toggle override).

---
**Factory Session:** https://app.factory.ai/sessions/KDk6DdPWHS4EriIrwm40 (created by szymonwoj@gmail.com)