### PR TITLE
Add optional Sankey visualization mode + backend API (Droid-assisted PR)

### DIFF
--- a/app/backend/data/sankey_default.json
+++ b/app/backend/data/sankey_default.json
@@ -1,0 +1,119 @@
+{
+  "meta": {
+    "version": 2,
+    "units": { "mass": "kg" },
+    "notes": "Measured masses from attached trial PDF; partial runs included. Use in-app scaling to 300 kg."
+  },
+  "nodes": [
+    { "id": "V1", "label": "V1 Screening Machine SIK", "type": "machine" },
+    { "id": "S1", "label": "0–0.3 mm", "type": "stream", "tags": ["size:0-0.3"] },
+    { "id": "V4", "label": "V4 Refining Blackmass SRV", "type": "machine" },
+    { "id": "P1", "label": "Black Mass 0–0.1", "type": "product", "tags": ["black_mass"] },
+    { "id": "S2", "label": "0.1–X (from V4)", "type": "stream" },
+
+    { "id": "S3", "label": "0.3–X mm", "type": "stream", "tags": ["size:0.3-X"] },
+    { "id": "V2", "label": "V2 Zigzag Sifter ZZS", "type": "machine" },
+    { "id": "S4", "label": "Heavy (SF)", "type": "stream", "tags": ["fraction:heavy"] },
+    { "id": "S5", "label": "Light (LF)", "type": "stream", "tags": ["fraction:light"] },
+    { "id": "V3", "label": "V3 Turbo Mill ARES", "type": "machine" },
+    { "id": "V3S", "label": "V3 Screening Machine SIK", "type": "machine" },
+
+    { "id": "S6", "label": "0–0.3 mm (after V3S)", "type": "stream", "tags": ["size:0-0.3"] },
+    { "id": "V5", "label": "V5 Refining Blackmass SRV", "type": "machine" },
+    { "id": "P2", "label": "Black Mass 0–0.1 (from V5)", "type": "product", "tags": ["black_mass"] },
+    { "id": "S7", "label": "0.1–X (from V5)", "type": "stream" },
+
+    { "id": "S8", "label": "0.3–0.5 mm", "type": "stream", "tags": ["size:0.3-0.5"] },
+    { "id": "V7", "label": "V7 Air Table TTS", "type": "machine" },
+    { "id": "S9", "label": "Heavy (Cu) 0.3–0.5", "type": "stream", "tags": ["fraction:heavy"] },
+    { "id": "S10", "label": "Light (Al) 0.3–0.5", "type": "stream", "tags": ["fraction:light"] },
+    { "id": "V10", "label": "V10 Barrier Separator WSB (0.3–0.5)", "type": "machine" },
+    { "id": "P3", "label": "Al", "type": "product", "tags": ["metal:Al"] },
+    { "id": "P4", "label": "Mix", "type": "product" },
+    { "id": "P5", "label": "Plastic", "type": "product" },
+    { "id": "PCu", "label": "Cu", "type": "product", "tags": ["metal:Cu"] },
+    { "id": "PFe", "label": "Fe", "type": "product", "tags": ["metal:Fe"] },
+
+    { "id": "S11", "label": "0.5–1.0 mm", "type": "stream", "tags": ["size:0.5-1.0"] },
+    { "id": "V8", "label": "V8 Air Table TTS", "type": "machine" },
+    { "id": "S12", "label": "Heavy (Cu) 0.5–1.0", "type": "stream", "tags": ["fraction:heavy"] },
+    { "id": "S13", "label": "Light (Al) 0.5–1.0", "type": "stream", "tags": ["fraction:light"] },
+    { "id": "V11", "label": "V11 Barrier Separator WSB (0.5–1.0)", "type": "machine" },
+    { "id": "P6", "label": "Al (0.5–1.0)", "type": "product", "tags": ["metal:Al"] },
+    { "id": "P7", "label": "Mix (0.5–1.0)", "type": "product" },
+    { "id": "P8", "label": "Plastic (0.5–1.0)", "type": "product" },
+
+    { "id": "S14", "label": "1.0–3.0 mm", "type": "stream", "tags": ["size:1.0-3.0"] },
+    { "id": "V9", "label": "V9 Air Table TTS", "type": "machine" },
+    { "id": "S15", "label": "Heavy (Cu) 1.0–3.0", "type": "stream", "tags": ["fraction:heavy"] },
+    { "id": "S16", "label": "Light (Al) 1.0–3.0", "type": "stream", "tags": ["fraction:light"] },
+    { "id": "V12", "label": "V12 Barrier Separator WSB (1.0–3.0)", "type": "machine" },
+    { "id": "P9", "label": "Al (1.0–3.0)", "type": "product", "tags": ["metal:Al"] },
+    { "id": "P10", "label": "Mix (1.0–3.0)", "type": "product" },
+    { "id": "P11", "label": "Plastic (1.0–3.0)", "type": "product" },
+
+    { "id": "S17", "label": "3.0–X mm", "type": "stream", "tags": ["size:3.0-X"] },
+    { "id": "P12", "label": "Plastic / Foils", "type": "product", "tags": ["plastic"] },
+
+    { "id": "F1", "label": "Filter", "type": "machine" },
+    { "id": "V6", "label": "V6 Refining Blackmass SRV (Filter stream)", "type": "machine" },
+    { "id": "P13", "label": "Black Mass 0–0.1 (from V6)", "type": "product", "tags": ["black_mass"] },
+    { "id": "P14", "label": "Separator Foil 0.1–X", "type": "product", "tags": ["foil"] }
+  ],
+  "links": [
+    { "id": "L1",  "from": "V1",  "to": "S1",  "measured_kg": 176.0 },
+    { "id": "L2",  "from": "V1",  "to": "S3",  "measured_kg": 210.0 },
+
+    { "id": "L3",  "from": "S3",  "to": "V2" },
+    { "id": "L4",  "from": "V2",  "to": "S4",  "measured_kg": 5.9 },
+    { "id": "L5",  "from": "V2",  "to": "S5",  "measured_kg": 202.0 },
+    { "id": "L6",  "from": "S4",  "to": "V3",  "measured_kg": 5.9 },
+    { "id": "L7",  "from": "S5",  "to": "V3",  "measured_kg": 202.0 },
+    { "id": "L8",  "from": "V3",  "to": "V3S" },
+
+    { "id": "L9",  "from": "V3S", "to": "S6",  "measured_kg": 102.0 },
+    { "id": "L10", "from": "V3S", "to": "S8",  "measured_kg": 25.0 },
+    { "id": "L11", "from": "V3S", "to": "S11", "measured_kg": 34.0 },
+    { "id": "L12", "from": "V3S", "to": "S14", "measured_kg": 15.0 },
+    { "id": "L13", "from": "V3S", "to": "S17", "measured_kg": 26.0 },
+
+    { "id": "L14", "from": "S6",  "to": "V5" },
+    { "id": "L15", "from": "V5",  "to": "P2",  "measured_kg": 77.0 },
+    { "id": "L16", "from": "V5",  "to": "S7",  "measured_kg": 8.6 },
+
+    { "id": "L17", "from": "S8",  "to": "V7",  "measured_kg": 22.0 },
+    { "id": "L18", "from": "V7",  "to": "S9",  "measured_kg": 11.7 },
+    { "id": "L19", "from": "V7",  "to": "S10", "measured_kg": 10.3 },
+    { "id": "L20", "from": "S10", "to": "V10", "measured_kg": 7.75 },
+    { "id": "L21", "from": "V10", "to": "P3",  "measured_kg": 3.8 },
+    { "id": "L22", "from": "V10", "to": "P4",  "measured_kg": 3.45 },
+    { "id": "L23", "from": "V10", "to": "PCu", "measured_kg": 0.4 },
+    { "id": "L24", "from": "V10", "to": "PFe", "measured_kg": 0.1 },
+
+    { "id": "L25", "from": "S11", "to": "V8",  "measured_kg": 26.8 },
+    { "id": "L26", "from": "V8",  "to": "S12", "measured_kg": 9.3 },
+    { "id": "L27", "from": "V8",  "to": "S13", "measured_kg": 17.5 },
+    { "id": "L28", "from": "S13", "to": "V11", "measured_kg": 13.15 },
+    { "id": "L29", "from": "V11", "to": "P6",  "measured_kg": 8.1 },
+    { "id": "L30", "from": "V11", "to": "P7",  "measured_kg": 4.45 },
+    { "id": "L31", "from": "V11", "to": "PCu", "measured_kg": 0.5 },
+    { "id": "L32", "from": "V11", "to": "PFe", "measured_kg": 0.1 },
+
+    { "id": "L33", "from": "S14", "to": "V9",  "measured_kg": 11.6 },
+    { "id": "L34", "from": "V9",  "to": "S15", "measured_kg": 9.5 },
+    { "id": "L35", "from": "V9",  "to": "S16", "measured_kg": 2.1 },
+    { "id": "L36", "from": "S15", "to": "V12", "measured_kg": 6.9 },
+    { "id": "L37", "from": "V12", "to": "P9",  "measured_kg": 1.8 },
+    { "id": "L38", "from": "V12", "to": "P10", "measured_kg": 2.55 },
+    { "id": "L39", "from": "V12", "to": "PCu", "measured_kg": 2.45 },
+    { "id": "L40", "from": "V12", "to": "PFe", "measured_kg": 0.1 },
+
+    { "id": "L41", "from": "S17", "to": "P12", "measured_kg": 26.0 },
+
+    { "id": "L42", "from": "F1",  "to": "V6",  "measured_kg": 52.2 },
+    { "id": "L43", "from": "V6",  "to": "P13", "measured_kg": 46.0 },
+    { "id": "L44", "from": "V6",  "to": "P14", "measured_kg": 6.2 }
+  ],
+  "sources": ["V1", "F1"],
+  "sinks": ["P1","P2","P3","P4","P5","P6","P7","P8","P9","P10","P11","P12","P13","P14","PCu","PFe"]
+}

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -31,6 +31,10 @@ import chem
 import peaks
 from models import METALS_DATA
 
+# Sankey router ----------------------------------------------------------- #
+# (added for optional Sankey-diagram functionality)
+from sankey_api import router as sankey_router
+
 # Environment configuration
 APP_ENV = os.getenv("APP_ENV", "dev")
 MAX_UPLOAD_MB = int(os.getenv("MAX_UPLOAD_MB", "10"))
@@ -51,6 +55,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Register additional routers (kept separate for clarity)
+app.include_router(sankey_router, prefix="/api/sankey")
 
 # --------------------------------------------------------------------------- #
 # Initialise shared state to keep the most recent compute result

--- a/app/backend/sankey_api.py
+++ b/app/backend/sankey_api.py
@@ -1,0 +1,153 @@
+"""
+FastAPI router for Sankey diagram functionality.
+Provides endpoints for graph management and scaling.
+"""
+import json
+import os
+from pathlib import Path
+from typing import Dict, List, Optional, Union, Literal
+
+from fastapi import APIRouter, Request, HTTPException, Body
+from pydantic import BaseModel
+
+from sankey_models import Graph, Meta, Node, Link, scale_graph_global, normalize_graph
+
+# Create router
+router = APIRouter(tags=["sankey"])
+
+# Default graph path
+DEFAULT_GRAPH_PATH = Path(__file__).parent / "data" / "sankey_default.json"
+
+class ScaleRequest(BaseModel):
+    """Request model for scaling a graph"""
+    batch_target_kg: float
+    strategy: Literal["global", "per-node"] = "global"
+
+def load_default_graph() -> Graph:
+    """Load default graph from JSON file if it exists"""
+    if not DEFAULT_GRAPH_PATH.exists():
+        # Return empty graph if default doesn't exist
+        return Graph(
+            meta=Meta(batch_target_kg=300.0),
+            nodes=[],
+            links=[],
+            sources=[],
+            sinks=[]
+        )
+    
+    try:
+        with open(DEFAULT_GRAPH_PATH, "r") as f:
+            data = json.load(f)
+            return Graph.model_validate(data)
+    except Exception as e:
+        # Return empty graph on error
+        print(f"Error loading default graph: {e}")
+        return Graph(
+            meta=Meta(batch_target_kg=300.0),
+            nodes=[],
+            links=[],
+            sources=[],
+            sinks=[]
+        )
+
+@router.get("/graph", response_model=Graph)
+async def get_graph(request: Request) -> Graph:
+    """
+    Get the current Sankey graph.
+    
+    If no graph exists in app state, load the default graph.
+    """
+    # Check if graph exists in app state
+    if not hasattr(request.app.state, "sankey_graph"):
+        # Load default graph
+        request.app.state.sankey_graph = load_default_graph()
+    
+    return request.app.state.sankey_graph
+
+@router.post("/graph", response_model=Graph)
+async def set_graph(request: Request, graph: Graph) -> Graph:
+    """
+    Set the current Sankey graph.
+    
+    Normalizes the graph before storing.
+    """
+    # Normalize graph
+    normalized_graph = normalize_graph(graph)
+    
+    # Store in app state
+    request.app.state.sankey_graph = normalized_graph
+    
+    return normalized_graph
+
+@router.post("/scale", response_model=Graph)
+async def scale_graph(
+    request: Request, 
+    scale_request: ScaleRequest = Body(...)
+) -> Graph:
+    """
+    Scale the current graph based on target batch size.
+    
+    Does not modify the stored graph.
+    """
+    # Get current graph
+    if not hasattr(request.app.state, "sankey_graph"):
+        request.app.state.sankey_graph = load_default_graph()
+    
+    current_graph = request.app.state.sankey_graph
+    
+    # Scale graph based on strategy
+    if scale_request.strategy == "global":
+        scaled_graph = scale_graph_global(
+            current_graph, 
+            batch_target_kg=scale_request.batch_target_kg
+        )
+    elif scale_request.strategy == "per-node":
+        # Not implemented yet, fall back to global
+        # TODO: Implement per-node scaling
+        scaled_graph = scale_graph_global(
+            current_graph, 
+            batch_target_kg=scale_request.batch_target_kg
+        )
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported scaling strategy: {scale_request.strategy}"
+        )
+    
+    # Return scaled graph without modifying stored graph
+    return scaled_graph
+
+@router.post("/import", response_model=Graph)
+async def import_data(
+    request: Request,
+    file_content: str = Body(..., embed=True),
+    file_type: Literal["json", "csv"] = Body("json", embed=True)
+) -> Graph:
+    """
+    Import graph data from JSON or CSV.
+    
+    Currently only supports JSON import.
+    """
+    if file_type == "json":
+        try:
+            data = json.loads(file_content)
+            graph = Graph.model_validate(data)
+            normalized_graph = normalize_graph(graph)
+            request.app.state.sankey_graph = normalized_graph
+            return normalized_graph
+        except Exception as e:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid JSON format: {str(e)}"
+            )
+    elif file_type == "csv":
+        # Not implemented yet
+        raise HTTPException(
+            status_code=501,
+            detail="CSV import not implemented yet"
+        )
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported file type: {file_type}"
+        )

--- a/app/backend/sankey_models.py
+++ b/app/backend/sankey_models.py
@@ -1,0 +1,152 @@
+"""
+Pydantic models for Sankey diagram data structures.
+Includes scaling and normalization helpers.
+"""
+from typing import Dict, List, Optional, Union, Any, Literal
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+class Meta(BaseModel):
+    """Metadata for Sankey graph"""
+    version: int = 2
+    units: Dict[str, str] = Field(default_factory=lambda: {"mass": "kg"})
+    notes: Optional[str] = None
+    batch_target_kg: Optional[float] = 300.0
+
+class Node(BaseModel):
+    """Node in Sankey diagram (machine, stream, or product)"""
+    id: str
+    label: str
+    type: Literal["machine", "stream", "product"]
+    tags: Optional[List[str]] = None
+    
+    @field_validator('id')
+    @classmethod
+    def id_must_be_valid(cls, v: str) -> str:
+        """Ensure ID is valid for Plotly Sankey"""
+        if not v:
+            raise ValueError("Node ID cannot be empty")
+        return v
+
+class Link(BaseModel):
+    """Link between nodes with optional measured and scaled masses"""
+    id: str
+    from_node: str = Field(..., alias="from")
+    to_node: str = Field(..., alias="to")
+    measured_kg: Optional[float] = None
+    scaled_kg: Optional[float] = None
+    percent_of_parent: Optional[float] = None
+    trial_id: Optional[str] = None
+    notes: Optional[str] = None
+    
+    class Config:
+        populate_by_name = True
+
+class Graph(BaseModel):
+    """Complete Sankey graph with nodes, links, and metadata"""
+    meta: Meta = Field(default_factory=Meta)
+    nodes: List[Node] = Field(default_factory=list)
+    links: List[Link] = Field(default_factory=list)
+    sources: List[str] = Field(default_factory=list)
+    sinks: List[str] = Field(default_factory=list)
+    
+    @model_validator(mode='after')
+    def validate_node_references(self) -> 'Graph':
+        """Ensure all node references in links exist"""
+        node_ids = {node.id for node in self.nodes}
+        for link in self.links:
+            if link.from_node not in node_ids:
+                raise ValueError(f"Link {link.id} references non-existent from_node: {link.from_node}")
+            if link.to_node not in node_ids:
+                raise ValueError(f"Link {link.id} references non-existent to_node: {link.to_node}")
+        return self
+
+def compute_total_input(graph: Graph) -> float:
+    """Calculate total input mass from source nodes"""
+    total = 0.0
+    
+    # If sources defined, use those
+    if graph.sources:
+        for source_id in graph.sources:
+            for link in graph.links:
+                if link.from_node == source_id and link.measured_kg is not None:
+                    total += link.measured_kg
+    # Otherwise, find nodes with no incoming links
+    else:
+        # Find nodes with no incoming links
+        incoming_nodes = {link.to_node for link in graph.links}
+        potential_sources = {node.id for node in graph.nodes} - incoming_nodes
+        
+        # Sum outgoing measured_kg from these nodes
+        for source_id in potential_sources:
+            for link in graph.links:
+                if link.from_node == source_id and link.measured_kg is not None:
+                    total += link.measured_kg
+    
+    return total
+
+def scale_graph_global(graph: Graph, batch_target_kg: Optional[float] = None) -> Graph:
+    """Scale all measured_kg values by a global factor"""
+    # Use target from graph.meta if not specified
+    target = batch_target_kg or graph.meta.batch_target_kg
+    if not target:
+        raise ValueError("Batch target must be specified")
+    
+    # Calculate total input
+    total_input = compute_total_input(graph)
+    if total_input <= 0:
+        raise ValueError("Total input mass must be positive")
+    
+    # Calculate scale factor
+    scale_factor = target / total_input
+    
+    # Create new graph with scaled values
+    new_graph = graph.model_copy(deep=True)
+    
+    # Scale all measured_kg values
+    for link in new_graph.links:
+        if link.measured_kg is not None:
+            link.scaled_kg = link.measured_kg * scale_factor
+    
+    return new_graph
+
+def normalize_graph(graph: Graph) -> Graph:
+    """Ensure graph has all required fields and normalize data"""
+    new_graph = graph.model_copy(deep=True)
+    
+    # Ensure meta exists
+    if new_graph.meta is None:
+        new_graph.meta = Meta()
+    
+    # Ensure sources and sinks exist
+    if not new_graph.sources:
+        # Find nodes with no incoming links
+        incoming_nodes = {link.to_node for link in new_graph.links}
+        new_graph.sources = [
+            node.id for node in new_graph.nodes 
+            if node.id not in incoming_nodes
+        ]
+    
+    if not new_graph.sinks:
+        # Find nodes with no outgoing links
+        outgoing_nodes = {link.from_node for link in new_graph.links}
+        new_graph.sinks = [
+            node.id for node in new_graph.nodes 
+            if node.id not in outgoing_nodes
+        ]
+    
+    # Compute percentages if not present
+    node_totals = {}
+    for link in new_graph.links:
+        if link.from_node not in node_totals:
+            node_totals[link.from_node] = 0.0
+        
+        if link.measured_kg is not None:
+            node_totals[link.from_node] += link.measured_kg
+    
+    for link in new_graph.links:
+        if (link.measured_kg is not None and 
+            node_totals.get(link.from_node, 0) > 0 and 
+            link.percent_of_parent is None):
+            link.percent_of_parent = link.measured_kg / node_totals[link.from_node] * 100
+    
+    return new_graph

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -10,6 +10,9 @@ import type {
   PeakAssignment,
 } from './api/client'
 
+// Sankey view --------------------------------------------------------------
+import SankeyView from './sankey/SankeyView'
+
 // Plotly --------------------------------------------------------------------
 import createPlotlyComponent from 'react-plotly.js/factory'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -27,6 +30,8 @@ function App() {
   const [uploading, setUploading] = useState(false)
   const [importData, setImportData] = useState<ImportResponse | null>(null)
   const [mapping, setMapping] = useState<ColumnMapping | null>(null)
+  // App mode: 'titration' (default) or 'sankey'
+  const [mode, setMode] = useState<'titration' | 'sankey'>('titration')
   const [settings, setSettings] = useState({
     c_b: 0.1,
     q: 1.0,
@@ -105,6 +110,13 @@ function App() {
     }
   }, [result])
 
+  /* ---------------------------------------------------------------------- */
+  /* Mode switch: if Sankey, short-circuit render                           */
+  /* ---------------------------------------------------------------------- */
+  if (mode === 'sankey') {
+    return <SankeyView onBack={() => setMode('titration')} />
+  }
+
   return (
     <main className="container" style={{ textAlign: 'left', maxWidth: 960, margin: '0 auto' }}>
       {/* ------------------------------------------------------------------ */}
@@ -115,6 +127,13 @@ function App() {
         {health.status === 'error' && <span style={{ color: 'red' }}>Backend error: {health.message}</span>}
         {health.status === 'ok' && <span style={{ color: 'green' }}>Backend OK</span>}
       </section>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Mode switch button                                                */}
+      {/* ------------------------------------------------------------------ */}
+      <div style={{ textAlign: 'right', marginBottom: '0.5rem' }}>
+        <button onClick={() => setMode('sankey')}>Switch to Sankey view</button>
+      </div>
 
       <h1>Miareczkowanie</h1>
 

--- a/app/frontend/src/api/sankey.ts
+++ b/app/frontend/src/api/sankey.ts
@@ -1,0 +1,160 @@
+/**
+ * API client for Sankey diagram functionality.
+ * Provides types and functions for interacting with the Sankey backend.
+ */
+
+/* ---------------------------------------------------------------------------
+ *  Types (matching backend Pydantic models)
+ * ------------------------------------------------------------------------- */
+
+export interface Meta {
+  version: number;
+  units: { mass: string };
+  notes?: string;
+  batch_target_kg?: number;
+}
+
+export interface Node {
+  id: string;
+  label: string;
+  type: "machine" | "stream" | "product";
+  tags?: string[];
+}
+
+export interface Link {
+  id: string;
+  from: string;
+  to: string;
+  measured_kg?: number;
+  scaled_kg?: number;
+  percent_of_parent?: number;
+  trial_id?: string;
+  notes?: string;
+}
+
+export interface Graph {
+  meta: Meta;
+  nodes: Node[];
+  links: Link[];
+  sources: string[];
+  sinks: string[];
+}
+
+export interface ScaleRequest {
+  batch_target_kg: number;
+  strategy: "global" | "per-node";
+}
+
+/* ---------------------------------------------------------------------------
+ *  API Functions
+ * ------------------------------------------------------------------------- */
+
+/**
+ * Get the current Sankey graph from the backend.
+ * @returns The current graph or default if none exists.
+ */
+export async function getGraph(): Promise<Graph> {
+  const response = await fetch('/api/sankey/graph');
+  
+  if (!response.ok) {
+    throw new Error(`Failed to get graph: ${await response.text()}`);
+  }
+  
+  return response.json() as Promise<Graph>;
+}
+
+/**
+ * Set the current Sankey graph on the backend.
+ * @param graph The graph to set
+ * @returns The normalized graph after processing
+ */
+export async function setGraph(graph: Graph): Promise<Graph> {
+  const response = await fetch('/api/sankey/graph', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(graph),
+  });
+  
+  if (!response.ok) {
+    throw new Error(`Failed to set graph: ${await response.text()}`);
+  }
+  
+  return response.json() as Promise<Graph>;
+}
+
+/**
+ * Scale the current graph based on target batch size.
+ * @param batchTargetKg The target batch size in kg
+ * @param strategy The scaling strategy ("global" or "per-node")
+ * @returns The scaled graph
+ */
+export async function scaleGraph(
+  batchTargetKg: number,
+  strategy: "global" | "per-node" = "global"
+): Promise<Graph> {
+  const request: ScaleRequest = {
+    batch_target_kg: batchTargetKg,
+    strategy,
+  };
+  
+  const response = await fetch('/api/sankey/scale', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(request),
+  });
+  
+  if (!response.ok) {
+    throw new Error(`Failed to scale graph: ${await response.text()}`);
+  }
+  
+  return response.json() as Promise<Graph>;
+}
+
+/**
+ * Import graph data from JSON or CSV.
+ * @param fileContent The content of the file as a string
+ * @param fileType The type of file ("json" or "csv")
+ * @returns The imported and normalized graph
+ */
+export async function importData(
+  fileContent: string,
+  fileType: "json" | "csv" = "json"
+): Promise<Graph> {
+  const response = await fetch('/api/sankey/import', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      file_content: fileContent,
+      file_type: fileType,
+    }),
+  });
+  
+  if (!response.ok) {
+    throw new Error(`Import failed: ${await response.text()}`);
+  }
+  
+  return response.json() as Promise<Graph>;
+}
+
+/**
+ * Helper to download graph as a file
+ * @param graph The graph to download
+ * @param filename The filename to suggest
+ */
+export function downloadGraph(graph: Graph, filename: string = "sankey_graph.json"): void {
+  const blob = new Blob([JSON.stringify(graph, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/app/frontend/src/sankey/SankeyView.tsx
+++ b/app/frontend/src/sankey/SankeyView.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useState, useRef, ChangeEvent } from 'react'
-import { Graph, getGraph, scaleGraph, importData, downloadGraph } from '../api/sankey'
+import { useEffect, useState, useRef } from 'react'
+import type { ChangeEvent } from 'react'
+import type { Graph } from '../api/sankey'
+import { getGraph, scaleGraph, importData, downloadGraph } from '../api/sankey'
 
 // Plotly --------------------------------------------------------------------
 import createPlotlyComponent from 'react-plotly.js/factory'

--- a/app/frontend/src/sankey/SankeyView.tsx
+++ b/app/frontend/src/sankey/SankeyView.tsx
@@ -1,0 +1,301 @@
+import { useEffect, useState, useRef, ChangeEvent } from 'react'
+import { Graph, getGraph, scaleGraph, importData, downloadGraph } from '../api/sankey'
+
+// Plotly --------------------------------------------------------------------
+import createPlotlyComponent from 'react-plotly.js/factory'
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore – plotly.js-dist-min has no types, but we ship @types/plotly.js for API
+import Plotly from 'plotly.js-dist-min'
+const Plot = createPlotlyComponent(Plotly)
+
+interface SankeyViewProps {
+  onBack?: () => void;
+}
+
+export default function SankeyView({ onBack }: SankeyViewProps) {
+  const [graph, setGraph] = useState<Graph | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [batchTarget, setBatchTarget] = useState(300)
+  const [useScaled, setUseScaled] = useState(false)
+  const [scaling, setScaling] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Load graph on mount
+  useEffect(() => {
+    let mounted = true
+    
+    const fetchGraph = async () => {
+      try {
+        setLoading(true)
+        const data = await getGraph()
+        if (mounted) {
+          setGraph(data)
+          if (data.meta.batch_target_kg) {
+            setBatchTarget(data.meta.batch_target_kg)
+          }
+        }
+      } catch (err) {
+        if (mounted) setError(`Failed to load graph: ${err instanceof Error ? err.message : String(err)}`)
+      } finally {
+        if (mounted) setLoading(false)
+      }
+    }
+    
+    fetchGraph()
+    
+    return () => {
+      mounted = false
+    }
+  }, [])
+
+  // Apply scaling
+  const handleScale = async () => {
+    if (!graph) return
+    
+    try {
+      setScaling(true)
+      const scaledGraph = await scaleGraph(batchTarget, "global")
+      setGraph(scaledGraph)
+      setUseScaled(true)
+    } catch (err) {
+      setError(`Scaling failed: ${err instanceof Error ? err.message : String(err)}`)
+    } finally {
+      setScaling(false)
+    }
+  }
+
+  // Handle file import
+  const handleImport = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    
+    try {
+      const fileContent = await file.text()
+      const fileType = file.name.toLowerCase().endsWith('.csv') ? 'csv' : 'json'
+      
+      const importedGraph = await importData(fileContent, fileType as any)
+      setGraph(importedGraph)
+      
+      if (importedGraph.meta.batch_target_kg) {
+        setBatchTarget(importedGraph.meta.batch_target_kg)
+      }
+      
+      // Reset file input
+      if (fileInputRef.current) {
+        fileInputRef.current.value = ''
+      }
+    } catch (err) {
+      setError(`Import failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  // Handle export
+  const handleExport = () => {
+    if (!graph) return
+    downloadGraph(graph, `sankey_graph_${new Date().toISOString().slice(0, 10)}.json`)
+  }
+
+  // Prepare Sankey data
+  const prepareSankeyData = () => {
+    if (!graph) return null
+    
+    // Map node IDs to indices for Plotly
+    const nodeMap: Record<string, number> = {}
+    graph.nodes.forEach((node, index) => {
+      nodeMap[node.id] = index
+    })
+    
+    // Prepare arrays for Plotly Sankey
+    const source: number[] = []
+    const target: number[] = []
+    const value: number[] = []
+    const labels: string[] = graph.nodes.map(n => n.label)
+    
+    // Color nodes by type
+    const colors: string[] = graph.nodes.map(node => {
+      switch (node.type) {
+        case 'machine': return '#e41a1c'  // Red
+        case 'stream': return '#377eb8'   // Blue
+        case 'product': return '#4daf4a'  // Green
+        default: return '#999999'         // Gray
+      }
+    })
+    
+    // Prepare links
+    graph.links.forEach(link => {
+      const sourceIndex = nodeMap[link.from]
+      const targetIndex = nodeMap[link.to]
+      
+      // Use scaled values if available and selected
+      const linkValue = useScaled && link.scaled_kg != null 
+        ? link.scaled_kg 
+        : link.measured_kg
+      
+      // Only add links with values
+      if (linkValue != null && linkValue > 0) {
+        source.push(sourceIndex)
+        target.push(targetIndex)
+        value.push(linkValue)
+      }
+    })
+    
+    return {
+      source,
+      target,
+      value,
+      labels,
+      colors
+    }
+  }
+
+  const sankeyData = prepareSankeyData()
+
+  return (
+    <main style={{ textAlign: 'left', width: '95%', margin: '0 auto' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+        <h1>Sankey Diagram</h1>
+        {onBack && (
+          <button onClick={onBack} style={{ padding: '0.5rem 1rem' }}>
+            Back to Titration
+          </button>
+        )}
+      </div>
+      
+      {error && (
+        <div style={{ background: '#ffeeee', padding: '0.5rem 1rem', marginBottom: '1rem', color: 'red' }}>
+          {error}
+          <button 
+            onClick={() => setError(null)} 
+            style={{ marginLeft: '1rem', border: 'none', background: 'transparent', cursor: 'pointer' }}
+          >
+            ✕
+          </button>
+        </div>
+      )}
+      
+      <div style={{ background: '#f4f4f4', padding: '1rem', marginBottom: '1rem' }}>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem', alignItems: 'center' }}>
+          <div>
+            <label>
+              Batch Target (kg):&nbsp;
+              <input
+                type="number"
+                value={batchTarget}
+                onChange={e => setBatchTarget(Number(e.target.value))}
+                style={{ width: '80px' }}
+                min="1"
+              />
+            </label>
+            <button 
+              onClick={handleScale} 
+              disabled={scaling || !graph}
+              style={{ marginLeft: '0.5rem' }}
+            >
+              {scaling ? 'Scaling...' : 'Apply Scaling'}
+            </button>
+          </div>
+          
+          <label style={{ display: 'flex', alignItems: 'center' }}>
+            <input
+              type="checkbox"
+              checked={useScaled}
+              onChange={e => setUseScaled(e.target.checked)}
+              disabled={!graph?.links.some(l => l.scaled_kg != null)}
+              style={{ marginRight: '0.5rem' }}
+            />
+            Show Scaled Values
+          </label>
+          
+          <div>
+            <input
+              type="file"
+              accept=".json,.csv"
+              onChange={handleImport}
+              ref={fileInputRef}
+              style={{ display: 'none' }}
+            />
+            <button onClick={() => fileInputRef.current?.click()}>
+              Import JSON/CSV
+            </button>
+            <button 
+              onClick={handleExport} 
+              disabled={!graph}
+              style={{ marginLeft: '0.5rem' }}
+            >
+              Export JSON
+            </button>
+          </div>
+        </div>
+      </div>
+      
+      {loading ? (
+        <div style={{ textAlign: 'center', padding: '2rem' }}>Loading Sankey data...</div>
+      ) : !graph ? (
+        <div style={{ textAlign: 'center', padding: '2rem' }}>No graph data available</div>
+      ) : sankeyData && sankeyData.source.length > 0 ? (
+        <Plot
+          style={{ width: '100%', height: '700px' }}
+          data={[
+            {
+              type: 'sankey',
+              orientation: 'h',
+              node: {
+                pad: 15,
+                thickness: 20,
+                line: {
+                  color: 'black',
+                  width: 0.5
+                },
+                label: sankeyData.labels,
+                color: sankeyData.colors
+              },
+              link: {
+                source: sankeyData.source,
+                target: sankeyData.target,
+                value: sankeyData.value,
+                hovertemplate: 
+                  '%{source.label} → %{target.label}<br>' +
+                  'Value: %{value:.2f} kg<br>' +
+                  '<extra></extra>'
+              }
+            }
+          ]}
+          layout={{
+            title: `Process Flow Sankey Diagram (${useScaled ? 'Scaled' : 'Measured'} Values)`,
+            font: {
+              size: 12
+            },
+            autosize: true,
+            margin: {
+              l: 25,
+              r: 25,
+              b: 25,
+              t: 50,
+              pad: 4
+            }
+          }}
+          useResizeHandler
+        />
+      ) : (
+        <div style={{ textAlign: 'center', padding: '2rem' }}>
+          Graph loaded but no valid links with values found
+        </div>
+      )}
+      
+      {graph && (
+        <div style={{ marginTop: '1rem', fontSize: '14px' }}>
+          <p>
+            <strong>Graph Info:</strong> {graph.meta.notes || 'No notes provided'}
+          </p>
+          <p>
+            <strong>Nodes:</strong> {graph.nodes.length} | 
+            <strong> Links:</strong> {graph.links.length} | 
+            <strong> Sources:</strong> {graph.sources.join(', ')} | 
+            <strong> Sinks:</strong> {graph.sinks.length} items
+          </p>
+        </div>
+      )}
+    </main>
+  )
+}


### PR DESCRIPTION
Summary
- Adds an optional Sankey visualization feature alongside the original titration app.
- Frontend: new Sankey view with batch-scaling controls, JSON import/export, and a mode switch in App.tsx.
- Backend: FastAPI router under /api/sankey with graph get/set/scale/import, Pydantic models, and a default graph JSON based on your trial measurements.

Files (high level)
- app/backend/sankey_models.py
- app/backend/sankey_api.py
- app/backend/data/sankey_default.json
- app/backend/main.py (include_router("/api/sankey"))
- app/frontend/src/api/sankey.ts
- app/frontend/src/sankey/SankeyView.tsx
- app/frontend/src/App.tsx (UI toggle)

Notes
- Non-breaking: original titration endpoints and UI remain unchanged; a button switches modes.
- Compose/NGINX unchanged and continue to serve /api; Sankey endpoints live under /api/sankey.
- Frontend static build still required before docker-compose up (vite build produces frontend/dist used by NGINX).

Validation
- Could not run local tests/build in this environment; please run CI to build frontend (vite build) and ensure FastAPI imports succeed. Changes are self-contained and follow existing stack (React + Plotly, FastAPI, compose + NGINX).

Next
- Optional: implement CSV import and per-node scaling strategy.

Droid-assisted PR.

---
**Factory Session:** https://app.factory.ai/sessions/X2Gr8yqgaTReiymeIHL9 (created by szymonwoj@gmail.com)